### PR TITLE
feat (FSO-306): создан пакет prober для упрощения healthcheck'ов

### DIFF
--- a/pkg/prober/edge/checker.go
+++ b/pkg/prober/edge/checker.go
@@ -1,7 +1,7 @@
 package edge
 
 // Status is a result of a check.
-type Status = int
+type Status int
 
 const (
 	StatusOk = Status(iota)
@@ -9,20 +9,20 @@ const (
 )
 
 // CheckFunc is a function used to check.
-type CheckFunc = func() Status
+type CheckFunc func() Status
 
 // HealthChecker provides health check.
-type HealthChecker = interface {
+type HealthChecker interface {
 	CheckHealth() Status
 }
 
 // ReadinessChecker provides readiness check.
-type ReadinessChecker = interface {
+type ReadinessChecker interface {
 	CheckReadiness() Status
 }
 
 // K8SChecker is a full standard k8s probes checker.
-type K8SChecker = interface {
+type K8SChecker interface {
 	HealthChecker
 	ReadinessChecker
 }

--- a/pkg/prober/edge/checker.go
+++ b/pkg/prober/edge/checker.go
@@ -1,0 +1,28 @@
+package edge
+
+// Status is a result of a check.
+type Status = int
+
+const (
+	StatusOk = Status(iota)
+	StatusBad
+)
+
+// CheckFunc is a function used to check.
+type CheckFunc = func() Status
+
+// HealthChecker provides health check.
+type HealthChecker = interface {
+	CheckHealth() Status
+}
+
+// ReadinessChecker provides readiness check.
+type ReadinessChecker = interface {
+	CheckReadiness() Status
+}
+
+// K8SChecker is a full standard k8s probes checker.
+type K8SChecker = interface {
+	HealthChecker
+	ReadinessChecker
+}

--- a/pkg/prober/edge/edge.go
+++ b/pkg/prober/edge/edge.go
@@ -1,0 +1,33 @@
+// Package edge implements multiple probe checks.
+package edge
+
+func checkAll(checks []CheckFunc) Status {
+	if checks == nil {
+		return StatusOk
+	}
+	for _, hc := range checks {
+		partialStatus := hc()
+		if partialStatus != StatusOk {
+			return partialStatus
+		}
+	}
+	return StatusOk
+}
+
+// Edge is an application edge.
+type Edge struct {
+	healthChecks    []CheckFunc
+	readinessChecks []CheckFunc
+}
+
+// CheckHealth is a HealthChecker implementation for Edge.
+// It is healthy if all of the healthChecks passed.
+func (e *Edge) CheckHealth() Status {
+	return checkAll(e.healthChecks)
+}
+
+// CheckReadiness is a ReadinessChecker implementation for Edge.
+// It is ready if all of the readyChecks passed.
+func (e *Edge) CheckReadiness() Status {
+	return checkAll(e.readinessChecks)
+}

--- a/pkg/prober/edge/edge_builder.go
+++ b/pkg/prober/edge/edge_builder.go
@@ -1,0 +1,50 @@
+package edge
+
+// Builder is a builder for application edge.
+type Builder struct {
+	healthChecks    []CheckFunc
+	readinessChecks []CheckFunc
+}
+
+// WithHealthChecker adds a health check to application edge.
+func (b *Builder) WithHealthChecker(checker HealthChecker) *Builder {
+	b.healthChecks = append(
+		b.healthChecks,
+		func() Status { return checker.CheckHealth() },
+	)
+	return b
+}
+
+// WithReadinessChecker adds a readiness check to application edge.
+func (b *Builder) WithReadinessChecker(checker ReadinessChecker) *Builder {
+	b.readinessChecks = append(
+		b.readinessChecks,
+		func() Status { return checker.CheckReadiness() },
+	)
+	return b
+}
+
+// WithK8SChecker adds a k8s checker to application edge.
+func (b *Builder) WithK8SChecker(checker K8SChecker) *Builder {
+	return b.WithHealthChecker(checker).WithReadinessChecker(checker)
+}
+
+// WithHealthCheckFunc adds a health CheckFunc to application edge.
+func (b *Builder) WithHealthCheckFunc(fnc CheckFunc) *Builder {
+	b.healthChecks = append(b.healthChecks, fnc)
+	return b
+}
+
+// WithReadinessCheckFunc adds a readiness CheckFunc to application edge.
+func (b *Builder) WithReadinessCheckFunc(fnc CheckFunc) *Builder {
+	b.readinessChecks = append(b.readinessChecks, fnc)
+	return b
+}
+
+// Build builds an application edge.
+func (b *Builder) Build() Edge {
+	return Edge{
+		healthChecks:    b.healthChecks,
+		readinessChecks: b.readinessChecks,
+	}
+}

--- a/pkg/prober/handlers.go
+++ b/pkg/prober/handlers.go
@@ -1,0 +1,43 @@
+package prober
+
+import (
+	"net/http"
+
+	"github.com/FSO-VK/final-project-vk-backend/pkg/prober/edge"
+	"github.com/sirupsen/logrus"
+)
+
+type Handlers struct {
+	appEdge *edge.Edge
+	logger  *logrus.Entry
+}
+
+func newHandlers(
+	appEdge *edge.Edge,
+	logger *logrus.Entry,
+) *Handlers {
+	return &Handlers{
+		appEdge: appEdge,
+		logger:  logger,
+	}
+}
+
+func (h *Handlers) Health(w http.ResponseWriter, req *http.Request) {
+	healthy := h.appEdge.CheckHealth()
+	if healthy != edge.StatusOk {
+		h.logger.Error("Application is not healthy")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handlers) Ready(w http.ResponseWriter, req *http.Request) {
+	ready := h.appEdge.CheckReadiness()
+	if ready != edge.StatusOk {
+		h.logger.Error("Application is not ready")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -1,0 +1,74 @@
+// Package prober provides a simple way to define application probes.
+package prober
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/FSO-VK/final-project-vk-backend/pkg/prober/edge"
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	Host string
+	Port string
+}
+
+// Address returns the full server address in host:port format.
+func (s *Config) Address() string {
+	return fmt.Sprintf("%s:%s", s.Host, s.Port)
+}
+
+// Prober is a wrapper for http server.
+type Prober struct {
+	config *Config
+	srv    *http.Server
+	logger *logrus.Entry
+}
+
+// New makes new Prober.
+func New(appEdge *edge.Edge, conf *Config, l *logrus.Entry) Prober {
+	handlers := newHandlers(appEdge, l)
+
+	router := http.NewServeMux()
+	router.HandleFunc("/healthz", handlers.Health)
+	router.HandleFunc("/readyz", handlers.Ready)
+
+	srv := &http.Server{
+		Addr:                         conf.Address(),
+		Handler:                      router,
+		ReadHeaderTimeout:            5 * time.Second,
+		DisableGeneralOptionsHandler: false,
+		TLSConfig:                    nil,
+		ReadTimeout:                  0,
+		WriteTimeout:                 0,
+		IdleTimeout:                  0,
+		MaxHeaderBytes:               0,
+		TLSNextProto:                 nil,
+		ConnState:                    nil,
+		ErrorLog:                     nil,
+		BaseContext:                  nil,
+		ConnContext:                  nil,
+		HTTP2:                        nil,
+		Protocols:                    nil,
+	}
+
+	return Prober{
+		config: conf,
+		srv:    srv,
+		logger: l,
+	}
+}
+
+// ListenAndServe raises prober server.
+func (p *Prober) ListenAndServe() error {
+	p.logger.Infof("Prober started on %s", p.config.Address())
+	return p.srv.ListenAndServe()
+}
+
+// Shutdown gracefully shutdowns the prober.
+func (s *Prober) Shutdown(ctx context.Context) error {
+	return s.srv.Shutdown(ctx)
+}


### PR DESCRIPTION
Для деплоя было бы удобнее иметь отдельный http сервер с поддержкой проверок проб. Вот собственно и он. Постарался сделать как можно меньше зависимостей, поэтому использован стандартный http сервер и роутер. Хотелось бы и логгер выпилить, но раз уж он во всей кодовой базе одинаковый, то можно оставить