### PR TITLE
fix (FSO-290-UTC): перевод всего в utc и новый формат add plan на вхо…

### DIFF
--- a/internal/planning/application/add_plan.go
+++ b/internal/planning/application/add_plan.go
@@ -116,8 +116,8 @@ func (s *AddPlanService) Execute(
 		AmountUnit:     amountUnit,
 		Condition:      newPlan.Condition(),
 		Status:         newPlan.Status().String(),
-		StartDate:      newPlan.CourseStart().Format(time.DateOnly),
-		EndDate:        newPlan.CourseEnd().Format(time.DateOnly),
+		StartDate:      newPlan.CourseStart().Format(time.RFC3339),
+		EndDate:        newPlan.CourseEnd().Format(time.RFC3339),
 		RecurrenceRule: newPlan.ScheduleIcal(),
 	}
 

--- a/internal/planning/application/show_schedule.go
+++ b/internal/planning/application/show_schedule.go
@@ -156,7 +156,7 @@ func (s *ShowScheduleService) scheduleList(
 						AmountValue:    amountValue,
 						AmountUnit:     amountUnit,
 						Status:         record.Status().String(),
-						PlannedAt:      record.PlannedTime(),
+						PlannedAt:      record.PlannedTime().UTC(),
 						TakenAt:        record.TakenAt(),
 					})
 				}
@@ -169,7 +169,7 @@ func (s *ShowScheduleService) scheduleList(
 			futureTimes = p.Schedule(
 				time.Date(
 					parsedStart.Year(), parsedStart.Month(), parsedStart.Day(),
-					0, 0, 0, 0, now.Location(),
+					0, 0, 0, 0, time.UTC,
 				).Add(s.createdShift),
 				parsedEnd,
 			)
@@ -177,7 +177,7 @@ func (s *ShowScheduleService) scheduleList(
 			futureTimes = p.Schedule(
 				time.Date(
 					now.Year(), now.Month(), now.Day(),
-					0, 0, 0, 0, now.Location(),
+					0, 0, 0, 0, time.UTC,
 				).Add(s.createdShift),
 				parsedEnd,
 			)
@@ -190,7 +190,7 @@ func (s *ShowScheduleService) scheduleList(
 				AmountValue:    amountValue,
 				AmountUnit:     amountUnit,
 				Status:         StatusIntakePlanned,
-				PlannedAt:      t,
+				PlannedAt:      t.UTC(),
 				TakenAt:        time.Time{},
 			})
 		}

--- a/internal/planning/application/show_schedule.go
+++ b/internal/planning/application/show_schedule.go
@@ -156,7 +156,7 @@ func (s *ShowScheduleService) scheduleList(
 						AmountValue:    amountValue,
 						AmountUnit:     amountUnit,
 						Status:         record.Status().String(),
-						PlannedAt:      record.PlannedTime().UTC(),
+						PlannedAt:      record.PlannedTime(),
 						TakenAt:        record.TakenAt(),
 					})
 				}
@@ -169,7 +169,7 @@ func (s *ShowScheduleService) scheduleList(
 			futureTimes = p.Schedule(
 				time.Date(
 					parsedStart.Year(), parsedStart.Month(), parsedStart.Day(),
-					0, 0, 0, 0, parsedStart.Location(),
+					0, 0, 0, 0, now.Location(),
 				).Add(s.createdShift),
 				parsedEnd,
 			)
@@ -190,10 +190,11 @@ func (s *ShowScheduleService) scheduleList(
 				AmountValue:    amountValue,
 				AmountUnit:     amountUnit,
 				Status:         StatusIntakePlanned,
-				PlannedAt:      t.UTC(),
+				PlannedAt:      t,
 				TakenAt:        time.Time{},
 			})
 		}
 	}
-	return append(futureScheduleList, pastScheduleList...), nil
+
+	return append(pastScheduleList, futureScheduleList...), nil
 }

--- a/internal/planning/domain/plan/plan.go
+++ b/internal/planning/domain/plan/plan.go
@@ -104,7 +104,6 @@ func (p *Plan) Schedule(from, to time.Time) []time.Time {
 // GenerateIntakeRecords is a factory for intake records related to the plan.
 func (p *Plan) GenerateIntakeRecords(from, to time.Time) ([]*intake.IntakeRecord, error) {
 	records := make([]*intake.IntakeRecord, 0)
-
 	times := p.Schedule(from, to)
 	for _, t := range times {
 		record, err := intake.NewIntakeRecord(

--- a/internal/planning/domain/plan/vo.go
+++ b/internal/planning/domain/plan/vo.go
@@ -82,7 +82,6 @@ func NewSchedule(start, end time.Time, rules []*rrule.RRule) (schedule, error) {
 			continue
 		}
 		// rule is limited by range
-		rule.DTStart(start)
 		rule.Until(end)
 		r = append(r, rule)
 	}

--- a/internal/planning/domain/plan/vo_test.go
+++ b/internal/planning/domain/plan/vo_test.go
@@ -27,11 +27,13 @@ func Test_schedule_Next(t *testing.T) {
 			end:   time.Date(2024, 1, 10, 9, 0, 0, 0, time.UTC),
 			rules: func() []*rrule.RRule {
 				rule1, err1 := rrule.NewRRule(rrule.ROption{
-					Freq:   rrule.DAILY,
-					Byhour: []int{9, 19},
+					Dtstart: time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC),
+					Freq:    rrule.DAILY,
+					Byhour:  []int{9, 19},
 				})
 				rule2, err2 := rrule.NewRRule(rrule.ROption{
 					// friday is a January 5, 2024
+					Dtstart:   time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC),
 					Byweekday: []rrule.Weekday{rrule.MO, rrule.WE, rrule.FR},
 					Freq:      rrule.WEEKLY,
 					Byhour:    []int{15},
@@ -50,8 +52,9 @@ func Test_schedule_Next(t *testing.T) {
 			end:   time.Date(2024, 1, 3, 9, 0, 0, 0, time.UTC),
 			rules: func() []*rrule.RRule {
 				rule, err := rrule.NewRRule(rrule.ROption{
-					Freq:   rrule.DAILY,
-					Byhour: []int{9},
+					Dtstart: time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC),
+					Freq:    rrule.DAILY,
+					Byhour:  []int{9},
 				})
 				if err != nil {
 					t.Fatalf("arrange failed: %v", err)


### PR DESCRIPTION
перевод всего в utc и новый формат add plan на вход принимает + tests поменял

на фронте нужно присылать готовое RRULE (в DTSTART должно быть разное время в том числе)
пример
```
{
  "medicationId": "{{drug_uuid}}",
  "amount": {
    "value": 5,
    "unit": "шт"
  },
    "condition": "Надо принять аспирин с верхней полки",      // -> ics.description / VEVENT.DESCRIPTION will map to notification body)
    "startDate": "2026-01-07T21:00:00Z",          // -> ics.dtstart
    "endDate": "2027-02-28T00:00:00.000Z",
    "recurrenceRule": ["DTSTART:20260107T210000Z\nFREQ=DAILY;INTERVAL=2;BYHOUR=21;BYMINUTE=00", "DTSTART:20260108T205900Z\nFREQ=DAILY;INTERVAL=2;BYHOUR=20;BYMINUTE=59"]        // -> RRULE (string in RFC5545 format) alt 
}   
```

тесты тоже пришлось поменять так как поменялось NewSchedule тк нам больше не надо устанавливать start руками он уже есть с фронта